### PR TITLE
Add support for strings in command handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Aegis Changelog
 
 ## Current master
-* No changes
+* Add support for strings in command handler
 
 ## 0.1.0 (TODO: Date)
 * Initial beta release (Bazal, __Nov2024)

--- a/src/commandHandler.lua
+++ b/src/commandHandler.lua
@@ -60,15 +60,49 @@ function commandHandler._initialize()
 				assert(player ~= nil, string.format("No player with UserId: %d", textSource.UserId))
 
 				local playerPermissionLevel = checkGroupPerms(player)
-				if playerPermissionLevel >= commandModule.PermissionLevel then
-					-- Clean up whitespace in the message so that extra spaces do not cause empty strings in the split
-					local cleanMessage = string.gsub(message, "%s+", " ")
-					-- Split up the message into individual words
-					local words = string.split(cleanMessage, " ")
-					-- The first word is the command, select all words except the first to pass in as arguments
-					local arguments = table.move(words, 2, #words, 1, {})
-					commandModule.Execute(player, arguments) -- May not work.
+				if playerPermissionLevel < commandModule.PermissionLevel then return end
+				-- Clean up whitespace in the message so that extra spaces do not cause empty strings in the split
+				local cleanMessage: string = message:gsub("%s+", " ")
+				-- Split up the message into individual words
+				local words: {string} = table.remove(cleanMessage:split(" "), 1) -- The first word is the command, select all words except the first
+				local arguments: {string} = table.create(0)
+				-- Parse words for string arguments
+				local inString: boolean = false
+				for index: number, segment: string in ipairs(words) do
+					local nextQuotation: number = segment:find("\"") or 0
+					if nextQuotation == 1 then
+						inString = true
+					elseif nextQuotation ~= 0 and not isEscaped(segment, nextQuotation) then
+						error("Unexpected `\"`")
+					end
+
+					repeat
+						nextQuotation = segment:find("\"", nextQuotation + 1)
+					until not nextQuotation or not isEscaped(segment, nextQuotation)
+					if nextQuotation then
+						inString = false
+					end
+
+					if inString and index + 1 <= #words then
+						words[index + 1] = segment .. " " .. words[index + 1]
+						continue
+					end
+
+					local argIsString: boolean = segment:sub(1, 1) == "\"" -- In a string, the first character should always be a quotation mark
+					if argIsString then
+						segment = segment:sub(2, -1)
+						if nextQuotation == segment:len() + 1 then
+							segment = segment:sub(1, -2)
+						else
+							error("Expected space after string argument #" .. #arguments)
+						end
+						segment = segment:gsub("\\\"", "\"")
+					end
+
+					table.insert(arguments, segment)
 				end
+
+				commandModule.Execute(player, table.unpack(arguments))
 			end)
 		end
 	end

--- a/src/commandHandler.lua
+++ b/src/commandHandler.lua
@@ -72,24 +72,26 @@ function commandHandler._initialize()
 				assert(player ~= nil, string.format("No player with UserId: %d", textSource.UserId))
 
 				local playerPermissionLevel = checkGroupPerms(player)
-				if playerPermissionLevel < commandModule.PermissionLevel then return end
+				if playerPermissionLevel < commandModule.PermissionLevel then
+					return
+				end
 				-- Clean up whitespace in the message so that extra spaces do not cause empty strings in the split
 				local cleanMessage: string = message:gsub("%s+", " ")
 				-- Split up the message into individual words
-				local words: {string} = table.remove(cleanMessage:split(" "), 1) -- The first word is the command, select all words except the first
-				local arguments: {string} = table.create(0)
+				local words: { string } = table.remove(cleanMessage:split(" "), 1) -- The first word is the command, select all words except the first
+				local arguments: { string } = table.create(0)
 				-- Parse words for string arguments
 				local inString: boolean = false
 				for index: number, segment: string in ipairs(words) do
-					local nextQuotation: number = segment:find("\"") or 0
+					local nextQuotation: number = segment:find('"') or 0
 					if nextQuotation == 1 then
 						inString = true
 					elseif nextQuotation ~= 0 and not isEscaped(segment, nextQuotation) then
-						error("Unexpected `\"`")
+						error('Unexpected `"`')
 					end
 
 					repeat
-						nextQuotation = segment:find("\"", nextQuotation + 1)
+						nextQuotation = segment:find('"', nextQuotation + 1)
 					until not nextQuotation or not isEscaped(segment, nextQuotation)
 					if nextQuotation then
 						inString = false
@@ -100,7 +102,7 @@ function commandHandler._initialize()
 						continue
 					end
 
-					local argIsString: boolean = segment:sub(1, 1) == "\"" -- In a string, the first character should always be a quotation mark
+					local argIsString: boolean = segment:sub(1, 1) == '"' -- In a string, the first character should always be a quotation mark
 					if argIsString then
 						segment = segment:sub(2, -1)
 						if nextQuotation == segment:len() + 1 then
@@ -108,7 +110,7 @@ function commandHandler._initialize()
 						else
 							error("Expected space after string argument #" .. #arguments)
 						end
-						segment = segment:gsub("\\\"", "\"")
+						segment = segment:gsub('\\"', '"')
 					end
 
 					table.insert(arguments, segment)

--- a/src/commandHandler.lua
+++ b/src/commandHandler.lua
@@ -23,6 +23,18 @@ local function checkGroupPerms(player: Player): number
 		return 0
 	end
 end
+local function isEscaped(str: string, characterIndex: number): boolean
+	local backslashCount: number = 0
+	for _: number = 1, str:len() do
+		characterIndex -= 1
+		if str:sub(characterIndex, characterIndex) == "\\" then
+			backslashCount += 1
+		else
+			break
+		end
+	end
+	return math.fmod(backslashCount, 2) == 1
+end
 
 local commandHandler = {
 	_initialized = false,


### PR DESCRIPTION
Some commands may take multiple strings as arguments. There should be a way to pass strings into these commands.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* [x] Added/updated documentation
